### PR TITLE
Implement new driver interface for upgrade drivers

### DIFF
--- a/kostyor_openstack_ansible/upgrades/alt.py
+++ b/kostyor_openstack_ansible/upgrades/alt.py
@@ -35,13 +35,13 @@ def _run_playbook(self, playbook, cwd=None, ignore_errors=False):
 
 
 @app.task(bind=True, base=tasks.execute.__class__)
-def _run_playbook_for(self, playbook, node, service, cwd=None,
+def _run_playbook_for(self, playbook, nodes, service, cwd=None,
                       ignore_errors=False):
     inventory = Inventory(DataLoader(), VariableManager())
     hosts = [
         host.get_vars()['inventory_hostname']
-        for host in base.get_component_hosts_on_node(
-            inventory, service, node
+        for host in base.get_component_hosts_on_nodes(
+            inventory, service, nodes
         )
     ]
 

--- a/kostyor_openstack_ansible/upgrades/ref.py
+++ b/kostyor_openstack_ansible/upgrades/ref.py
@@ -160,10 +160,10 @@ def _run_playbook(playbook, cwd=None, ignore_errors=False):
 
 
 @app.task
-def _run_playbook_for(playbook, host, service, cwd=None, ignore_errors=False):
+def _run_playbook_for(playbook, hosts, service, cwd=None, ignore_errors=False):
     return _run_playbook_impl(
         playbook,
-        lambda inv: base.get_component_hosts_on_node(inv, service, host),
+        lambda inv: base.get_component_hosts_on_nodes(inv, service, hosts),
         cwd=cwd,
         ignore_errors=ignore_errors
     )

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,6 +15,7 @@
 
 import json
 import os
+import uuid
 
 import mock
 
@@ -56,26 +57,13 @@ def get_inventory_instance(inventory, popen, _):
     return Inventory(loader, VariableManager(), 'fake_dynamic_inventory.py')
 
 
-class host_ctx(object):
-    """A simple context manager that mocks dbapi.get_host() to return a host
-    with a specified hostname. It's important since this dbapi method is used
-    internally to determine hostname of the node to be upgraded.
-
-    :param hostname: a hostname of the host to be returned by dbapi.get_host()
-    :type hostname: str
-    """
-
-    def __init__(self, hostname):
-        self._patcher = mock.patch(
-            'kostyor_openstack_ansible.upgrades.base.dbapi.get_host',
-            return_value={
-                'id': '1ecdf50f-16c2-4f7e-ba10-77bfeb2d2062',
-                'cluster_id': '254dbd94-b426-484e-9155-4b60736cdef2',
-                'hostname': hostname,
-            })
-
-    def __enter__(self):
-        return self._patcher.start()
-
-    def __exit__(self, type_, value, traceback):
-        self._patcher.stop()
+def get_hosts(*hostnames):
+    cluster_id = str(uuid.uuid4())
+    return [
+        {
+            'id': str(uuid.uuid4()),
+            'cluster_id': cluster_id,
+            'hostname': hostname
+        }
+        for hostname in hostnames
+    ]

--- a/tests/upgrades/test_alt.py
+++ b/tests/upgrades/test_alt.py
@@ -21,7 +21,7 @@ import pytest
 from kostyor.rpc import app, tasks
 from kostyor_openstack_ansible.upgrades import alt
 
-from ..common import get_fixture, get_inventory_instance, host_ctx
+from ..common import get_fixture, get_inventory_instance, get_hosts
 
 
 class TestDriver(object):
@@ -56,8 +56,8 @@ class TestDriver(object):
         self.driver = alt.Driver()
 
     @mock.patch('kostyor.rpc.tasks.execute.si', return_value=tasks.noop.si())
-    def test_pre_upgrade_hook(self, execute):
-        self.driver.pre_upgrade_hook(mock.Mock())()
+    def test_pre_upgrade(self, execute):
+        self.driver.pre_upgrade()()
 
         execute.assert_called_once_with(
             '/opt/openstack-ansible/scripts/bootstrap-ansible.sh',
@@ -108,14 +108,8 @@ class TestDriver(object):
                 cwd='/opt/openstack-ansible/playbooks'),
         ]
 
-    def test_start_upgrade_runs_playbook(self):
-        with host_ctx('compute1') as host:
-            self.driver.start_upgrade(
-                mock.Mock(),
-                {
-                    'name': 'nova-compute',
-                    'host_id': host['id'],
-                })()
+    def test_start_runs_playbook(self):
+        self.driver.start({'name': 'nova-compute'}, get_hosts('compute1'))()
 
         self.popen.assert_called_once_with(
             [
@@ -127,20 +121,51 @@ class TestDriver(object):
             cwd=None,
         )
 
+    def test_start_runs_playbook_on_few_hosts(self):
+        self.driver.start(
+            {'name': 'horizon-wsgi'}, get_hosts('infra1', 'infra2'))()
+
+        self.popen.assert_called_once_with(
+            [
+                '/usr/local/bin/openstack-ansible',
+                '/opt/openstack-ansible/playbooks/os-horizon-install.yml',
+                '-l',
+                ','.join([
+                    'infra1_horizon_container-afb604da',
+                    'infra2_horizon_container-b7a45742',
+                ]),
+            ],
+            cwd=None,
+        )
+
     def test_start_upgrade_runs_playbook_once_on_one_host(self):
-        with host_ctx('infra2') as host:
-            self.driver.start_upgrade(
-                mock.Mock(),
-                {
-                    'name': 'nova-api',
-                    'host_id': host['id'],
-                })()
-            self.driver.start_upgrade(
-                mock.Mock(),
-                {
-                    'name': 'nova-conductor',
-                    'host_id': host['id'],
-                })()
+        hosts = get_hosts('infra2')
+
+        self.driver.start({'name': 'nova-api'}, hosts)()
+        self.driver.start({'name': 'nova-conductor'}, hosts)()
+
+        assert self.popen.call_args[0][0][0:3] == [
+            '/usr/local/bin/openstack-ansible',
+            '/opt/openstack-ansible/playbooks/os-nova-install.yml',
+            '-l',
+        ]
+
+        assert set(self.popen.call_args[0][0][3].split(',')) == set([
+            'infra2_nova_api_metadata_container-a542f3a5',
+            'infra2_nova_api_os_compute_container-d088a5c5',
+            'infra2_nova_cert_container-f4bebee6',
+            'infra2_nova_conductor_container-c9d5c8ec',
+            'infra2_nova_console_container-14f4435d',
+            'infra2_nova_scheduler_container-ea104a41',
+        ])
+
+    def test_start_runs_playbook_once_on_few_hosts(self):
+        host1, host2 = get_hosts('infra1', 'infra2')
+
+        # The second .start(...) must trigger playbook only for host2 as
+        # host1 was upgrades by first call.
+        self.driver.start({'name': 'nova-api'}, [host1])()
+        self.driver.start({'name': 'nova-conductor'}, [host1, host2])()
 
         assert self.popen.call_args[0][0][0:3] == [
             '/usr/local/bin/openstack-ansible',
@@ -158,13 +183,7 @@ class TestDriver(object):
         ])
 
     def test_start_upgrade_skip_not_supported_service(self):
-        with host_ctx('infra1') as host:
-            self.driver.start_upgrade(
-                mock.Mock(),
-                {
-                    'name': 'not-supported-service',
-                    'host_id': host['id'],
-                })()
+        self.driver.start({'name': 'unknown-service'}, get_hosts('infra1'))()
 
         self.popen.assert_not_called()
 
@@ -172,7 +191,7 @@ class TestDriver(object):
         self.popen.return_value.returncode = 42
 
         with pytest.raises(Exception) as excinfo:
-            self.test_start_upgrade_runs_playbook()
+            self.test_start_runs_playbook()
 
         excinfo.match(
             r'Command \'/usr/local/bin/openstack-ansible '

--- a/tests/upgrades/test_base.py
+++ b/tests/upgrades/test_base.py
@@ -25,23 +25,37 @@ class TestGetServiceContainersForHost(object):
     def test_only_infra1_keystone_container(self):
         inventory = get_inventory_instance(self._inventory)
 
-        component_hosts = base.get_component_hosts_on_node(
+        component_hosts = base.get_component_hosts_on_nodes(
             inventory,
             {'name': 'keystone-wsgi-admin'},
-            {'hostname': 'infra1'},
+            [{'hostname': 'infra1'}],
         )
 
         assert set([host.get_name() for host in component_hosts]) == set([
             'infra1_keystone_container-4d65b5ea',
         ])
 
+    def test_only_infra1_and_infra2_horizon_container(self):
+        inventory = get_inventory_instance(self._inventory)
+
+        component_hosts = base.get_component_hosts_on_nodes(
+            inventory,
+            {'name': 'horizon-wsgi'},
+            [{'hostname': 'infra1'}, {'hostname': 'infra2'}],
+        )
+
+        assert set([host.get_name() for host in component_hosts]) == set([
+            'infra1_horizon_container-afb604da',
+            'infra2_horizon_container-b7a45742',
+        ])
+
     def test_only_infra2_nova_containers(self):
         inventory = get_inventory_instance(self._inventory)
 
-        component_hosts = base.get_component_hosts_on_node(
+        component_hosts = base.get_component_hosts_on_nodes(
             inventory,
             {'name': 'nova-conductor'},
-            {'hostname': 'infra2'},
+            [{'hostname': 'infra2'}],
         )
 
         hosts = set([host.get_name() for host in component_hosts])
@@ -57,10 +71,10 @@ class TestGetServiceContainersForHost(object):
     def test_only_compute1_nova_on_host(self):
         inventory = get_inventory_instance(self._inventory)
 
-        component_hosts = base.get_component_hosts_on_node(
+        component_hosts = base.get_component_hosts_on_nodes(
             inventory,
             {'name': 'nova-compute'},
-            {'hostname': 'compute1'},
+            [{'hostname': 'compute1'}],
         )
 
         assert set([host.get_name() for host in component_hosts]) == set([
@@ -70,10 +84,10 @@ class TestGetServiceContainersForHost(object):
     def test_no_keystone_on_compute(self):
         inventory = get_inventory_instance(self._inventory)
 
-        component_hosts = base.get_component_hosts_on_node(
+        component_hosts = base.get_component_hosts_on_nodes(
             inventory,
             {'name': 'keystone-wsgi-admin'},
-            {'hostname': 'compute1'},
+            [{'hostname': 'compute1'}],
         )
 
         assert set([host.get_name() for host in component_hosts]) == set([])


### PR DESCRIPTION
Recently Kostyor changed its upgrade driver interface. The rationale was
to introduce a unified interface suited for both node-by-node and
service-by-service engines (or even more). The main change is in start
upgrade signature that now looks this way:

  start(self, service, hosts)

where:

  * `service` - a service to be upgraded
  * `hosts` - a list of hosts to run upgrade on

So this change adapts new interface and from now on drivers methods can
run playbook limited to multiple baremetal nodes.